### PR TITLE
Replaced off_t with int64_t in filemap.c for UNIX

### DIFF
--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -179,7 +179,7 @@ YR_API int yr_filemap_map_fd(
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
-    off_t offset,
+    int64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {
@@ -293,7 +293,7 @@ YR_API int yr_filemap_map_ex(
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,
-    off_t offset,
+    int64_t offset,
     size_t size,
     YR_MAPPED_FILE* pmapped_file)
 {


### PR DESCRIPTION
RetDec couldn't be compiled with the `i686-linux-gnu` toolchain since `off_t` is 32bit and not 64. I forced `int64_t` type for UNIX systems so it can be compiled with a 32bit toolchain.